### PR TITLE
build: Add /usr/local/include to include path for imgui

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ file(GLOB IMGUI_GLOB
     )
 
 add_library("imgui" STATIC ${IMGUI_GLOB})
-target_include_directories("imgui" PUBLIC ${IMGUI_PATH})
+target_include_directories("imgui" PUBLIC ${IMGUI_PATH} /usr/local/include)
 target_link_libraries("imgui" PRIVATE glfw)
 
 # Add the executable


### PR DESCRIPTION
### Description
This allows compilation on FreeBSD as imgui's glfw_cpp backend needs `GL/gl.h `located typically under the `/usr/local/include` path.

### Changes Made
- Append /usr/local/include to imgui's target_include_directories.

### Related Issues
See #10. May or may not be an issue just on FreeBSD.

### Additional Notes
Compiling the GLFW submodule will also require that [devel/evdev-proto](https://www.freshports.org/devel/evdev-proto/) is present in the system via ports or `pkg install evdev-proto`. The package provides the `linux/input.h` header.