### PR TITLE
fix: Update git tag of submodule in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ include(FetchContent)
 FetchContent_Declare(
 	glm
 	GIT_REPOSITORY	https://github.com/g-truc/glm.git
-	GIT_TAG 	bf71a834948186f4097caa076cd2663c69a10e1e #refs/tags/1.0.1
+	GIT_TAG 	master
 )
 
 FetchContent_MakeAvailable(glm)


### PR DESCRIPTION
### Description
The Git tag for glm was outdated. Fixed the git tag to the master branch of glm.

### Changes Made
Changed the version of glm from 1.0.1, latest release build as of 1.0.1 to the master branch.

### Related Issues
Fixes #17 

### Additional Notes
None
