### PR TITLE
feat + fixes + doc: Added hot reloading shaders, reenabled back face culling, fixed MSYS building, fixed some warnings, improved README.md

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED OFF)    # changed to off
 file(GLOB SOURCES "src/main.cpp")
 
 if(WIN32)
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Xlinker /errorlimit:0")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Xlinker")
 endif()
 
 # Add GLAD
@@ -23,7 +23,7 @@ add_subdirectory(libs/glfw)
 set(GLFW_BUILD_EXAMPLES OFF)
 set(GLFW_BUILD_TESTS OFF)
 set(GLFW_BUILD_DOCS OFF)
-# GLM
+# GLM (Requires internet for fetch)
 include(FetchContent)
 
 FetchContent_Declare(

--- a/README.md
+++ b/README.md
@@ -39,19 +39,27 @@ git submodule update --init
 
 ### Linux, Mac OS, MSYS (Windows)
 
-(Type release as argument to build optimized release version)
-
 ```sh
 ./build.sh
 ```
 
 ### Windows - Visual Studio
 
-(Type release as argument to build optimized release version)
-
 ```bat
 .\build.bat
 ```
+
+### Build flags
+
+To specify building the optimized release version or debug version, add the argument `release` or `debug` to the build script.
+
+Example:
+
+```
+./build.sh release
+```
+
+If no flag is given, the debug version is built by default.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Voxel Engine
 
-![preview](https://github.com/user-attachments/assets/f4f6eb2c-5e47-4f15-8a8e-db896befeffd)
+https://github.com/user-attachments/assets/47b3f7ce-3157-46a5-8faa-bcd0c895aa4a
 
 ## Overview
 
@@ -74,3 +74,4 @@ Our voxel engine is currently a work-in-progress, but we still welcome contribut
 
 This project is licensed under the MIT License.
 See [LICENSE](LICENSE) for details.
+

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ https://github.com/user-attachments/assets/47b3f7ce-3157-46a5-8faa-bcd0c895aa4a
 
 ![overview](assets/overview.png)
 
-### Controls
+## Controls
 WASD - Move\
 Space - Move upwards\
 Shift - Move downwards\
@@ -15,12 +15,18 @@ X - Toggle chunk generation\
 R - Hot reload shaders\
 Mouse - Look around
 
-### Instructions
+## Instructions
 
 Make sure to clone this repository recursively!
 
 ```
 git clone https://github.com/compsci-adl/voxel-engine --recursive
+```
+
+Can also clone with shallow submodules to save space:
+
+```
+git clone https://github.com/compsci-adl/voxel-engine --recursive --shallow-submodules
 ```
 
 If you have cloned it non-recursively:
@@ -33,11 +39,15 @@ git submodule update --init
 
 ### Linux, Mac OS, MSYS (Windows)
 
+(Type release as argument to build optimized release version)
+
 ```sh
 ./build.sh
 ```
 
 ### Windows - Visual Studio
+
+(Type release as argument to build optimized release version)
 
 ```bat
 .\build.bat
@@ -74,4 +84,3 @@ Our voxel engine is currently a work-in-progress, but we still welcome contribut
 
 This project is licensed under the MIT License.
 See [LICENSE](LICENSE) for details.
-

--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@
 
 ![overview](assets/overview.png)
 
+### Controls
+WASD - Move\
+Space - Move upwards\
+Shift - Move downwards\
+B - Display debug menu\
+X - Toggle chunk generation\
+R - Hot reload shaders\
+Mouse - Look around
+
 ### Instructions
 
 Make sure to clone this repository recursively!

--- a/libs/learnopengl/shader_m.h
+++ b/libs/learnopengl/shader_m.h
@@ -18,58 +18,16 @@ public:
     Shader() { }
     Shader(const char* vertexPath, const char* fragmentPath)
     {
-        // 1. retrieve the vertex/fragment source code from filePath
-        std::string vertexCode;
-        std::string fragmentCode;
-        std::ifstream vShaderFile;
-        std::ifstream fShaderFile;
-        // ensure ifstream objects can throw exceptions:
-        vShaderFile.exceptions (std::ifstream::failbit | std::ifstream::badbit);
-        fShaderFile.exceptions (std::ifstream::failbit | std::ifstream::badbit);
-        try 
-        {
-            // open files
-            vShaderFile.open(vertexPath);
-            fShaderFile.open(fragmentPath);
-            std::stringstream vShaderStream, fShaderStream;
-            // read file's buffer contents into streams
-            vShaderStream << vShaderFile.rdbuf();
-            fShaderStream << fShaderFile.rdbuf();		
-            // close file handlers
-            vShaderFile.close();
-            fShaderFile.close();
-            // convert stream into string
-            vertexCode = vShaderStream.str();
-            fragmentCode = fShaderStream.str();			
-        }
-        catch (std::ifstream::failure& e)
-        {
-            std::cout << "ERROR::SHADER::FILE_NOT_SUCCESSFULLY_READ: " << e.what() << std::endl;
-        }
-        const char* vShaderCode = vertexCode.c_str();
-        const char * fShaderCode = fragmentCode.c_str();
-        // 2. compile shaders
-        unsigned int vertex, fragment;
-        // vertex shader
-        vertex = glCreateShader(GL_VERTEX_SHADER);
-        glShaderSource(vertex, 1, &vShaderCode, NULL);
-        glCompileShader(vertex);
-        checkCompileErrors(vertex, "VERTEX");
-        // fragment Shader
-        fragment = glCreateShader(GL_FRAGMENT_SHADER);
-        glShaderSource(fragment, 1, &fShaderCode, NULL);
-        glCompileShader(fragment);
-        checkCompileErrors(fragment, "FRAGMENT");
-        // shader Program
-        ID = glCreateProgram();
-        glAttachShader(ID, vertex);
-        glAttachShader(ID, fragment);
-        glLinkProgram(ID);
-        checkCompileErrors(ID, "PROGRAM");
-        // delete the shaders as they're linked into our program now and no longer necessary
-        glDeleteShader(vertex);
-        glDeleteShader(fragment);
-
+        // Load shader program
+        loadShader(vertexPath, fragmentPath);
+    }
+    // Reload shaders, deletes previous shader program then executes loadShader function
+    void reloadShader(const char *vertexPath, const char *fragmentPath)
+    {
+        // Delete previous shader program to prevent memory leaks
+        glDeleteProgram(ID);
+        // Load shader program
+        loadShader(vertexPath, fragmentPath);
     }
     // activate the shader
     // ------------------------------------------------------------------------
@@ -137,6 +95,59 @@ public:
     }
 
 private:
+    // Load shader program
+    void loadShader(const char *vertexPath, const char *fragmentPath) {
+        // 1. retrieve the vertex/fragment source code from filePath
+        std::string vertexCode;
+        std::string fragmentCode;
+        std::ifstream vShaderFile;
+        std::ifstream fShaderFile;
+        // ensure ifstream objects can throw exceptions:
+        vShaderFile.exceptions(std::ifstream::failbit | std::ifstream::badbit);
+        fShaderFile.exceptions(std::ifstream::failbit | std::ifstream::badbit);
+        try {
+            // open files
+            vShaderFile.open(vertexPath);
+            fShaderFile.open(fragmentPath);
+            std::stringstream vShaderStream, fShaderStream;
+            // read file's buffer contents into streams
+            vShaderStream << vShaderFile.rdbuf();
+            fShaderStream << fShaderFile.rdbuf();
+            // close file handlers
+            vShaderFile.close();
+            fShaderFile.close();
+            // convert stream into string
+            vertexCode = vShaderStream.str();
+            fragmentCode = fShaderStream.str();
+        } catch (std::ifstream::failure &e) {
+            std::cout << "ERROR::SHADER::FILE_NOT_SUCCESSFULLY_READ: "
+                      << e.what() << std::endl;
+        }
+        const char *vShaderCode = vertexCode.c_str();
+        const char *fShaderCode = fragmentCode.c_str();
+        // 2. compile shaders
+        unsigned int vertex, fragment;
+        // vertex shader
+        vertex = glCreateShader(GL_VERTEX_SHADER);
+        glShaderSource(vertex, 1, &vShaderCode, NULL);
+        glCompileShader(vertex);
+        checkCompileErrors(vertex, "VERTEX");
+        // fragment Shader
+        fragment = glCreateShader(GL_FRAGMENT_SHADER);
+        glShaderSource(fragment, 1, &fShaderCode, NULL);
+        glCompileShader(fragment);
+        checkCompileErrors(fragment, "FRAGMENT");
+        // shader Program
+        ID = glCreateProgram();
+        glAttachShader(ID, vertex);
+        glAttachShader(ID, fragment);
+        glLinkProgram(ID);
+        checkCompileErrors(ID, "PROGRAM");
+        // delete the shaders as they're linked into our program now and no
+        // longer necessary
+        glDeleteShader(vertex);
+        glDeleteShader(fragment);
+    }
     // utility function for checking shader compilation/linking errors.
     // ------------------------------------------------------------------------
     void checkCompileErrors(GLuint shader, std::string type)

--- a/src/Block.h
+++ b/src/Block.h
@@ -138,7 +138,7 @@ void Block::creatColourCube(glm::vec3 pos, glm::vec3 size, glm::vec3 colour,
 
      // front, back, left, right, top, bottom
 
-    glm::vec3 n1;       // for normal??, not used. 
+    // glm::vec3 n1;       // for normal??, not used. 
     // front face
     addColCubeFace(p1, p2, p3, p4, colour, 0.86f, vertices, indices, vCount, iCount);
 

--- a/src/ChunkManager.h
+++ b/src/ChunkManager.h
@@ -235,11 +235,11 @@ void ChunkManager::pregenerateChunks() {
 
     std::vector<std::future<void>> futures; // Store futures to manage threads
 
-    for (float i = -halfWorldSize; i < halfWorldSize;
+    for (float i = (float)-halfWorldSize; i < halfWorldSize;
          i += Chunk::CHUNK_SIZE * Block::BLOCK_RENDER_SIZE) {
-        for (float j = -halfWorldSize; j < halfWorldSize;
+        for (float j = (float)-halfWorldSize; j < halfWorldSize;
              j += Chunk::CHUNK_SIZE * Block::BLOCK_RENDER_SIZE) {
-            for (float k = -halfWorldSize; k < halfWorldSize;
+            for (float k = (float)-halfWorldSize; k < halfWorldSize;
                  k += Chunk::CHUNK_SIZE * Block::BLOCK_RENDER_SIZE) {
 
                 if (j > -Block::BLOCK_RENDER_SIZE) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -180,9 +180,9 @@ int main() {
 
 
     // optional: back face culling
-    // glEnable(GL_CULL_FACE);   // Enable backface culling
-	// glCullFace(GL_BACK);      // Cull back faces
-	// glFrontFace(GL_CCW);   
+    glEnable(GL_CULL_FACE);   // Enable backface culling
+	glCullFace(GL_BACK);      // Cull back faces
+	glFrontFace(GL_CCW);   
 
 
     char fpsStr[32] = "FPS: 0";
@@ -250,7 +250,23 @@ int main() {
 
         // input
         // -----
+        // Process inputs for movement and debugging
         processInput(window, &cursorOn);
+        // Press r to hot reload shaders
+        if (glfwGetKey(window, GLFW_KEY_R) == GLFW_PRESS) {
+            // Reload terrainShader and set it to use texture1 (terrain textures)
+            terrainShader->reloadShader("src/shaders/terrain.vert",
+                                        "src/shaders/terrain.frag");
+            terrainShader->use();
+            terrainShader->setInt("texture1", 0);
+            terrainShader->setFloat("texWidth", (1.0f / (float)blockTextures.atlasCols));
+            terrainShader->setFloat("texHeight", (1.0f / (float)blockTextures.atlasRows));
+            // Reload defaultShader and blockShader
+            defaultShader->reloadShader("src/shaders/shader.vert",
+                                        "src/shaders/shader.frag");
+            blockShader->reloadShader("src/shaders/basic.vert",
+                                        "src/shaders/basic.frag");
+        }
 
         // render
         // ------
@@ -523,7 +539,7 @@ int calculateFPS(float deltaTime) {
         return fps;
     }
 
-    return -1.0;
+    return -1;
 }
 
 // Function to calculate and return the RAM usage as a string
@@ -632,7 +648,7 @@ void createMovingBlocksWave(ChunkMesh<float> * entityMesh, float deltaTime){
             float phaseOffset = (x * 0.7f + z * 0.5f) * 3.14159f;
             
             // Calculate wave that starts from corner (0,0) and ripples to corner (9,9)
-            float distanceFromCorner = sqrt(x*x + z*z); // Distance from origin corner
+            float distanceFromCorner = (float)sqrt(x*x + z*z); // Distance from origin corner
             float waveSpeed = 2.0f;
             float waveFreq = 0.5f;
             float blockY = sin(time * waveSpeed + distanceFromCorner * waveFreq) * 2.0f;


### PR DESCRIPTION
### Description
I added and fixed a number of low hanging fruit tasks.
1. Hot reloading shaders is the main feature of this pull request. By pressing the 'r' key at any time, edited shaders (inside src/shaders) can be reloaded while the program is still running. Useful for speeding up development.
2. Back face culling was uncommented in the code. I re-enabled it as it did not seem to cause any adverse effects and gave some extra performance.
3. The program now builds in the MSYS environment again (tested with ucrt64, mingw64, and clang64 environments using g++ for the former two and clang++ for the latter). I deleted /errorlimit:0 from the if(WIN32) section of in CMakeLists.txt as it would cause an error when building. Also threw a warning about being an invalid argument when building with Visual Studio 2022. Unsure why this was there in the first place.
4. Fixed warnings due to not casting certain variables and numbers to a different type.
5. Added controls to the README.md, including debug keys which would otherwise have to be found by looking at the input code or pressing keys until found.
6. Recorded a new video for the project that shows an up to date version of the program, replacing the old gif in README.md.
7. Added information on how to build release version and clone the repository with shallow submodules to README.md.

### Changes Made
As seen in the commits and above:
* Hot reload shaders by pressing r
* Re-enabled back face culling
* Fixed building in MSYS
* Fixed some warnings
* Added controls for program into README.md
* Updated video in README.md
* Added how to build release and clone with shallow submodules to README.md

### Related Issues
N/A

### Additional Notes
N/A